### PR TITLE
chore: remove deprecated `set-output` command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Running Prettier
       id: prettier-run
       shell: bash
-      run: echo "::set-output name=prettier-output::$(prettier --list-different --config ${{ inputs.config_path }} --ignore-path ${{ inputs.ignore_path }} --no-error-on-unmatched-pattern ${{ inputs.file_pattern }})"
+      run: echo "prettier-output=$(prettier --list-different --config ${{ inputs.config_path }} --ignore-path ${{ inputs.ignore_path }} --no-error-on-unmatched-pattern ${{ inputs.file_pattern }})" >> $GITHUB_OUTPUT
 
     - name: Fail On Error
       id: fail-on-error


### PR DESCRIPTION
### Solved or Linked Issues

None

### Description and Changes

This changes addresses the warning from GitHub:

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Your checklist for this pull request

🚨Please review the [guidelines for contributing](../README.md) to this repository.

- [x] Make sure you are requesting to **pull a work/topic/feature/bugfix branch** (right side). Don't request your default branch!
- [ ] Make sure you are making a pull request against the **development** (left side). Also you should start _your branch_ off _default branch_ and follow the branch naming guidelines.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.
- [ ] I have added necessary documentation and mentioned the related issues (if appropriate)
- [ ] I have added the appropriate labels, requested a review from a repository manager and assigned myself to this pull request.

### Post merge checklist

- [ ] Follow steps from the [guidelines for contributing](../blob/development/CONTRIBUTING.md) to this repository.
