### PR TITLE
Fix multiline output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,13 +39,19 @@ runs:
     - name: Running Prettier
       id: prettier-run
       shell: bash
-      run: echo "prettier-output=$(prettier --list-different --config ${{ inputs.config_path }} --ignore-path ${{ inputs.ignore_path }} --no-error-on-unmatched-pattern ${{ inputs.file_pattern }})" >> $GITHUB_OUTPUT
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "prettier-output<<$EOF" >> $GITHUB_OUTPUT
+        echo "$(prettier --list-different --config ${{ inputs.config_path }} --ignore-path ${{ inputs.ignore_path }} --no-error-on-unmatched-pattern ${{ inputs.file_pattern }})" >> $GITHUB_OUTPUT
+        echo "$EOF" >> $GITHUB_OUTPUT
 
     - name: Fail On Error
       id: fail-on-error
       if: steps.prettier-run.outputs.prettier-output != 0 && steps.prettier-run.outputs.prettier-output != '' && inputs.fail_on_error
       shell: bash
-      run: exit 1
+      run: |
+        echo "Found errors"
+        exit 1
 
 branding:
   icon: 'search'


### PR DESCRIPTION
### Solved or Linked Issues

Executing this action resulted in an output processing error.
```
Error: Unable to process file command 'output' successfully.
Error: Invalid format
```

### Description and Changes

I updated the output command according to the solutions here
https://stackoverflow.com/questions/74137120/how-to-fix-or-avoid-error-unable-to-process-file-command-output-successfully

I checked it is working.

